### PR TITLE
Fix corpses facing incorrectly in versions 1.20.2 and above.

### DIFF
--- a/src/main/java/com/github/unldenis/corpse/logic/packet/WrapperNamedEntitySpawn.java
+++ b/src/main/java/com/github/unldenis/corpse/logic/packet/WrapperNamedEntitySpawn.java
@@ -75,9 +75,27 @@ public class WrapperNamedEntitySpawn implements IPacket {
           .write(0, this.location.getX())
           .write(1, this.location.getY())
           .write(2, this.location.getZ());
-      packet.getBytes()
-          .write(0, (byte) (this.location.getYaw() * 256.0F / 360.0F))
-          .write(1, (byte) (this.location.getPitch() * 256.0F / 360.0F));
+
+      if (VersionUtil.isCompatible(VersionUtil.VersionEnum.V1_20) && VersionUtil.isAbovePatch(VersionUtil.VersionEnum.V1_20_R2)) {
+        float legacyYaw = this.location.getYaw();
+        float patchedYaw;
+        if (legacyYaw < 0) {
+          patchedYaw = 360 + legacyYaw;
+        } else {
+          patchedYaw = legacyYaw;
+        }
+
+        packet.getBytes()
+                .write(0, (byte) (this.location.getPitch() * 256.0F / 360.0F))  //headPitch
+                .write(1, (byte) (192.0F - patchedYaw * 256.0F / 360.0F))  //bodyYaw
+                .write(2, (byte) (192.0F - this.location.getYaw() * 256.0F / 360.0F));  //headYaw
+
+      } else {
+        packet.getBytes()
+                .write(0, (byte) (this.location.getYaw() * 256.0F / 360.0F))
+                .write(1, (byte) (this.location.getPitch() * 256.0F / 360.0F));
+      }
+
       if (VersionUtil.isAbove(VersionUtil.VersionEnum.V1_20)) {
           packet.getEntityTypeModifier()
               .write(0, EntityType.PLAYER);

--- a/src/main/java/com/github/unldenis/corpse/util/VersionUtil.java
+++ b/src/main/java/com/github/unldenis/corpse/util/VersionUtil.java
@@ -51,6 +51,10 @@ public class VersionUtil {
     return isAbove(ve1) && isBelow(ve2);
   }
 
+  public static boolean isAbovePatch(@NotNull VersionEnum veFull) {
+    return VersionEnum.valueOf(VERSION.toUpperCase()).getOrder() >= veFull.getOrder();
+  }
+
 
   public enum VersionEnum {
 
@@ -66,7 +70,13 @@ public class VersionUtil {
     V1_17(10),
     V1_18(11),
     V1_19(12),
-    V1_20(13);
+    V1_20(13),
+    V1_20_R1(14),
+    V1_20_R2(15),
+    V1_20_R3(16),
+    V1_20_R4(17),
+    V1_20_R5(18),
+    V1_20_R6(19);
 
     private final int order;
 


### PR DESCRIPTION
PR: Fix corpses facing incorrectly in versions 1.20.2 and above. 😊

😢BTW, If start the server with version 1.20.3+ and install ViaVersion and ViaBackwards., then players join with version 1.20~1.20.1, the corpses will still face the same direction. If players join with version 1.18, then the logic of setting the corpse direction will be messed up.

If start the server with version 1.20.1, the corpse plugin does not seem to work properly and even does not seem to show corpses.