### PR TITLE
Fix: replace spigot with spigot-api to resolve missing dependency and build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!--This adds the Spigot API artifact to the build -->
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
This pull request updates the Maven dependency from ``spigot`` to ``spigot-api`` in the pom.xml.
The previous artifact (spigot) could not be resolved, which caused the project to fail building both locally and on JitPack.

Using ``spigot-api`` resolves the dependency correctly and allows the project to build successfully again.

**Changes:**
- Updated ``artifactId`` from ``spigot`` → ``spigot-api``
- Fixed build failure caused by unresolved dependency